### PR TITLE
カスタム投稿タイプ、カスタムタクソノミーの追加

### DIFF
--- a/wp_data/wp-content/themes/mytheme/functions.php
+++ b/wp_data/wp-content/themes/mytheme/functions.php
@@ -1,3 +1,55 @@
 <?php
 
-    require_once(get_template_directory() . '/myblock/myblock.php');
+/* ---------- カスタムブロックの追加 ---------- */
+require_once(get_template_directory() . '/myblock/myblock.php');
+
+/* ---------- サムネイル画像の追加 ---------- */
+add_theme_support('post-thumbnails');
+
+/* ---------- カスタム投稿の追加 ---------- */
+function create_post_type()
+{
+    register_post_type( // カスタム投稿タイプの追加関数
+        'FY2023', //カスタム投稿タイプ名（半角英数字の小文字）
+        array( //オプション（以下）
+          'label' => '2023年度', // 管理画面上の表示（日本語でもOK）
+          'public' => true, // 管理画面に表示するかどうかの指定
+          'has_archive' => true, // 投稿した記事の一覧ページを作成する
+          'menu_position' => 5, // 管理画面メニューの表示位置（投稿の下に追加）
+          'show_in_rest' => true, // Gutenbergの有効化
+          'supports' => array( // サポートする機能（以下）
+            'title',  // タイトル
+            'editor', // エディター
+            'thumbnail', // アイキャッチ画像
+            'revisions' // リビジョンの保存
+          ),
+        )
+    );
+}
+add_action('init', 'create_post_type');
+
+/* ---------- カスタムタクソノミー（カテゴリー）の追加 ---------- */
+function custom_taxonomy_cat()
+{
+    register_taxonomy( // カスタムタクソノミーの追加関数
+        'naming', // カテゴリーの名前（半角英数字の小文字）
+        'FY2023',     // タグを追加したいカスタム投稿タイプ
+        array(      // オプション（以下
+          'label' => 'ネーム', // 表示名称
+          'public' => true, // 管理画面に表示するかどうかの指定
+          'hierarchical' => true, // 階層を持たせるかどうか
+          'show_in_rest' => true, // REST APIの有効化。ブロックエディタの有効化。
+        )
+    );
+    register_taxonomy( // カスタムタクソノミーの追加関数
+        'completed_manuscript', // カテゴリーの名前（半角英数字の小文字）
+        'FY2023',     // タグを追加したいカスタム投稿タイプ
+        array(      // オプション（以下
+          'label' => '本稿', // 表示名称
+          'public' => true, // 管理画面に表示するかどうかの指定
+          'hierarchical' => true, // 階層を持たせるかどうか
+          'show_in_rest' => true, // REST APIの有効化。ブロックエディタの有効化。
+        )
+    );
+}
+add_action('init', 'custom_taxonomy_cat');

--- a/wp_data/wp-content/themes/mytheme/functions.php
+++ b/wp_data/wp-content/themes/mytheme/functions.php
@@ -53,3 +53,12 @@ function custom_taxonomy_cat()
     );
 }
 add_action('init', 'custom_taxonomy_cat');
+
+/* ---------- ブロックテーマサポートの追加 ---------- */
+if (! function_exists('mytheme_setup')) {
+    function mytheme_setup()
+    {
+        add_theme_support('wp-block-styles');
+    }
+}
+add_action('after_setup_theme', 'mytheme_setup');

--- a/wp_data/wp-content/themes/mytheme/index.php
+++ b/wp_data/wp-content/themes/mytheme/index.php
@@ -1,3 +1,3 @@
-<?php get_header(); ?>
+<?php
 
-<?php get_footer();
+// Silence is golden.

--- a/wp_data/wp-content/themes/mytheme/parts/footer.html
+++ b/wp_data/wp-content/themes/mytheme/parts/footer.html
@@ -1,0 +1,4 @@
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Proudly powered by 
+    <a href="https://wordpress.org/">WordPress</a>.</p>
+<!-- /wp:paragraph -->

--- a/wp_data/wp-content/themes/mytheme/parts/header.html
+++ b/wp_data/wp-content/themes/mytheme/parts/header.html
@@ -1,0 +1,2 @@
+<!-- wp:site-title {"textAlign":"center"} /-->
+<!-- wp:site-tagline {"textAlign":"center"} /-->

--- a/wp_data/wp-content/themes/mytheme/style.css
+++ b/wp_data/wp-content/themes/mytheme/style.css
@@ -1,3 +1,10 @@
+/*
 Theme Name: mytheme
+Author: me
 Description: mytheme
+Version: 1.0
+Requires at least: 6.1
+Tested up to: latest
+Requires PHP: latest
 Text Domain: mytheme
+*/

--- a/wp_data/wp-content/themes/mytheme/templates/index.html
+++ b/wp_data/wp-content/themes/mytheme/templates/index.html
@@ -1,0 +1,5 @@
+<main class="wp-block-group">
+	<div class="wp-block-query alignwide">
+			<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
+	</div>
+</main>

--- a/wp_data/wp-content/themes/mytheme/templates/index.html
+++ b/wp_data/wp-content/themes/mytheme/templates/index.html
@@ -1,5 +1,25 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<div class="wp-block-query alignwide">
-			<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
-	</div>
+    <!-- wp:query -->
+    <div class="wp-block-query">
+        <!-- wp:post-template -->
+        <!-- wp:post-featured-image /-->
+        <!-- wp:post-title {"isLink":true} /-->
+        <!-- wp:post-author {"showAvatar":false} /-->
+        <!-- wp:post-date /-->
+        <!-- wp:post-terms {"term":"category"} /-->
+        <!-- wp:post-excerpt /-->
+        <!-- /wp:post-template -->
+
+        <!-- wp:query-pagination -->
+        <div class="wp-block-query-pagination">
+            <!-- wp:query-pagination-previous /-->
+            <!-- wp:query-pagination-next /-->
+        </div>
+        <!-- /wp:query-pagination -->
+    </div>
+    <!-- /wp:query -->
 </main>
+<!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp_data/wp-content/themes/mytheme/templates/single.html
+++ b/wp_data/wp-content/themes/mytheme/templates/single.html
@@ -1,0 +1,77 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+    <!-- wp:columns -->
+    <div class="wp-block-columns">
+        <!-- wp:column -->
+        <div class="wp-block-column">
+            <!-- wp:post-navigation-link {"type":"previous"} /-->
+        </div>
+        <!-- /wp:column -->
+
+        <!-- wp:column -->
+        <div class="wp-block-column">
+            <!-- wp:post-navigation-link /-->
+        </div>
+        <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+	<!-- wp:post-featured-image /-->
+	<!-- wp:post-title /-->
+	<!-- wp:post-author {"showAvatar":false} /-->
+	<!-- wp:post-date /-->
+	<!-- wp:post-terms {"term":"category"} /-->
+    <!-- wp:spacer {"height":40} -->
+    <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+    <!-- /wp:spacer -->
+	<!-- wp:post-content /-->
+    <!-- wp:spacer {"height":40} -->
+    <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+    <!-- /wp:spacer -->
+    <!-- wp:post-terms {"term":"post_tag"} /-->
+    <!-- wp:spacer {"height":100} -->
+    <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+    <!-- /wp:spacer -->
+    <!-- wp:heading {"className:"comments-title"} -->
+    <h2 class="comments-title">Comments</h2>
+    <!-- /wp:heading -->
+    <!-- wp:comments-query-loop -->
+    <div class="wp-block-comments-query-loop">
+        <!-- wp:comment-template -->
+        <!-- wp:columns -->
+        <div class="wp-block-columns">
+            <!-- wp:column {"width":"40px"} -->
+            <div class="wp-block-column" style="flex-basis:40px">
+                <!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /-->
+            </div>
+            <!-- /wp:column -->
+    
+            <!-- wp:column -->
+            <div class="wp-block-column">
+                <!-- wp:comment-author-name /-->
+                <!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"flex"}} -->
+                <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px">
+                    <!-- wp:comment-date /-->
+                    <!-- wp:comment-edit-link /-->
+                </div>
+                <!-- /wp:group -->
+                <!-- wp:comment-content /-->
+                <!-- wp:comment-reply-link /-->
+            </div>
+            <!-- /wp:column -->
+        </div>
+        <!-- /wp:columns -->
+    <!-- /wp:comment-template -->
+
+    <!-- wp:comments-pagination -->
+    <!-- wp:comments-pagination-previous /-->
+
+    <!-- wp:comments-pagination-numbers /-->
+
+    <!-- wp:comments-pagination-next /-->
+    <!-- /wp:comments-pagination -->
+    </div>
+    <!-- /wp:comments-query-loop -->
+</main>
+<!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/wp_data/wp-content/themes/mytheme/theme.json
+++ b/wp_data/wp-content/themes/mytheme/theme.json
@@ -1,15 +1,734 @@
 {
-    "version": 2,
-    "settings": {
-        "custom": {
-            "fruit": "apple"
-        },
-        "blocks": {
-            "core/paragraph": {
-                "custom": {
-                    "fruit": "pear"
-                }
-            }
-        }
-    }
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"customTemplates": [
+		{
+			"name": "blank",
+			"postTypes": [
+				"page",
+				"post"
+			],
+			"title": "Blank"
+		},
+		{
+			"name": "blog-alternative",
+			"postTypes": [
+				"page"
+			],
+			"title": "Blog (Alternative)"
+		},
+		{
+			"name": "404",
+			"postTypes": [
+				"page"
+			],
+			"title": "404"
+		}
+	],
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"color": "#ffffff",
+					"name": "Base",
+					"slug": "base"
+				},
+				{
+					"color": "#000000",
+					"name": "Contrast",
+					"slug": "contrast"
+				},
+				{
+					"color": "#9DFF20",
+					"name": "Primary",
+					"slug": "primary"
+				},
+				{
+					"color": "#345C00",
+					"name": "Secondary",
+					"slug": "secondary"
+				},
+				{
+					"color": "#F6F6F6",
+					"name": "Tertiary",
+					"slug": "tertiary"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "650px",
+			"wideSize": "1200px"
+		},
+		"spacing": {
+			"spacingScale": {
+				"steps": 0
+			},
+			"spacingSizes": [
+				{
+					"size": "clamp(1.5rem, 5vw, 2rem)",
+					"slug": "30",
+					"name": "1"
+				},
+				{
+					"size": "clamp(1.8rem, 1.8rem + ((1vw - 0.48rem) * 2.885), 3rem)",
+					"slug": "40",
+					"name": "2"
+				},
+				{
+					"size": "clamp(2.5rem, 8vw, 4.5rem)",
+					"slug": "50",
+					"name": "3"
+				},
+				{
+					"size": "clamp(3.75rem, 10vw, 7rem)",
+					"slug": "60",
+					"name": "4"
+				},
+				{
+					"size": "clamp(5rem, 5.25rem + ((1vw - 0.48rem) * 9.096), 8rem)",
+					"slug": "70",
+					"name": "5"
+				},
+				{
+					"size": "clamp(7rem, 14vw, 11rem)",
+					"slug": "80",
+					"name": "6"
+				}
+			],
+			"units": [
+				"%",
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw"
+			]
+		},
+		"typography": {
+			"dropCap": false,
+			"fluid": true,
+			"fontFamilies": [
+				{
+					"fontFace": [
+						{
+							"fontFamily": "DM Sans",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "400",
+							"src": [
+								"file:./assets/fonts/dm-sans/DMSans-Regular.woff2"
+							]
+						},
+						{
+							"fontFamily": "DM Sans",
+							"fontStretch": "normal",
+							"fontStyle": "italic",
+							"fontWeight": "400",
+							"src": [
+								"file:./assets/fonts/dm-sans/DMSans-Regular-Italic.woff2"
+							]
+						},
+						{
+							"fontFamily": "DM Sans",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "700",
+							"src": [
+								"file:./assets/fonts/dm-sans/DMSans-Bold.woff2"
+							]
+						},
+						{
+							"fontFamily": "DM Sans",
+							"fontStretch": "normal",
+							"fontStyle": "italic",
+							"fontWeight": "700",
+							"src": [
+								"file:./assets/fonts/dm-sans/DMSans-Bold-Italic.woff2"
+							]
+						}
+					],
+					"fontFamily": "\"DM Sans\", sans-serif",
+					"name": "DM Sans",
+					"slug": "dm-sans"
+				},
+				{
+					"fontFace": [
+						{
+							"fontDisplay": "block",
+							"fontFamily": "IBM Plex Mono",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "300",
+							"src": [
+								"file:./assets/fonts/ibm-plex-mono/IBMPlexMono-Light.woff2"
+							]
+						},
+						{
+							"fontDisplay": "block",
+							"fontFamily": "IBM Plex Mono",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "400",
+							"src": [
+								"file:./assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2"
+							]
+						},
+						{
+							"fontDisplay": "block",
+							"fontFamily": "IBM Plex Mono",
+							"fontStretch": "normal",
+							"fontStyle": "italic",
+							"fontWeight": "400",
+							"src": [
+								"file:./assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2"
+							]
+						},
+						{
+							"fontDisplay": "block",
+							"fontFamily": "IBM Plex Mono",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "700",
+							"src": [
+								"file:./assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2"
+							]
+						}
+					],
+					"fontFamily": "'IBM Plex Mono', monospace",
+					"name": "IBM Plex Mono",
+					"slug": "ibm-plex-mono"
+				},
+				{
+					"fontFace": [
+						{
+							"fontFamily": "Inter",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "200 900",
+							"src": [
+								"file:./assets/fonts/inter/Inter-VariableFont_slnt,wght.ttf"
+							]
+						}
+					],
+					"fontFamily": "\"Inter\", sans-serif",
+					"name": "Inter",
+					"slug": "inter"
+				},
+				{
+					"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
+					"name": "System Font",
+					"slug": "system-font"
+				},
+				{
+					"fontFace": [
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "200 900",
+							"src": [
+								"file:./assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2"
+							]
+						},
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontStretch": "normal",
+							"fontStyle": "italic",
+							"fontWeight": "200 900",
+							"src": [
+								"file:./assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2"
+							]
+						}
+					],
+					"fontFamily": "\"Source Serif Pro\", serif",
+					"name": "Source Serif Pro",
+					"slug": "source-serif-pro"
+				}
+			],
+			"fontSizes": [
+				{
+					"fluid": {
+						"min": "0.875rem",
+						"max": "1rem"
+					},
+					"size": "1rem",
+					"slug": "small"
+				},
+				{
+					"fluid": {
+						"min": "1rem",
+						"max": "1.125rem"
+					},
+					"size": "1.125rem",
+					"slug": "medium"
+				},
+				{
+					"fluid": {
+						"min": "1.75rem",
+						"max": "1.875rem"
+					},
+					"size": "1.75rem",
+					"slug": "large"
+				},
+				{
+					"fluid": false,
+					"size": "2.25rem",
+					"slug": "x-large"
+				},
+				{
+					"fluid": {
+						"min": "4rem",
+						"max": "10rem"
+					},
+					"size": "10rem",
+					"slug": "xx-large"
+				}
+			]
+		},
+		"useRootPaddingAwareAlignments": true
+	},
+	"styles": {
+		"blocks": {
+			"core/navigation": {
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"typography": {
+								"textDecoration": "none"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/post-author": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/post-content": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--secondary)"
+						}
+					}
+				}
+			},
+			"core/post-excerpt": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)"
+				}
+			},
+			"core/post-date": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "400"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
+			"core/post-terms": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/post-title": {
+				"spacing": {
+					"margin": {
+						"bottom": "1.25rem",
+						"top": "1.25rem"
+					}
+				},
+				"typography": {
+					"fontWeight": "400"
+				},
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"color": {
+								"text": "var(--wp--preset--color--secondary)"
+							},
+							"typography": {
+								"textDecoration": "none"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/comments-title":{
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				},
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--preset--spacing--40)"
+					}
+				}
+			},
+			"core/comment-author-name": {
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"color": {
+								"text": "var(--wp--preset--color--secondary)"
+							},
+							"typography": {
+								"textDecoration": "none"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/comment-date": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"color": {
+								"text": "var(--wp--preset--color--secondary)"
+							},
+							"typography": {
+								"textDecoration": "none"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/comment-edit-link": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/comment-reply-link": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/comments-pagination": {
+				"spacing": {
+					"margin": {
+						"top": "var(--wp--preset--spacing--40)"
+					}
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/pullquote": {
+				"border": {
+					"style": "solid",
+					"width": "1px 0"
+				},
+				"elements": {
+					"cite": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--small)",
+							"fontStyle": "normal",
+							"textTransform": "none"
+						}
+					}
+				},
+				"typography": {
+					"lineHeight": "1.3"
+				},
+				"spacing": {
+					"margin": {
+						"bottom": "var(--wp--preset--spacing--40) !important",
+						"top": "var(--wp--preset--spacing--40) !important"
+					}
+				}
+			},
+			"core/query": {
+				"elements": {
+					"h2": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--x-large)"
+						}
+					}
+				}
+			},
+			"core/query-pagination": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "400"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
+			"core/quote": {
+				"border": {
+					"width": "1px"
+				},
+				"elements": {
+					"cite": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--small)",
+							"fontStyle": "normal"
+						}
+					}
+				},
+				"spacing": {
+					"padding": {
+						"left": "var(--wp--preset--spacing--30)",
+						"right": "var(--wp--preset--spacing--30)"
+					}
+				}
+			},
+			"core/site-title": {
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						":focus": {
+							"typography": {
+								"textDecoration": "underline dashed"
+							}
+						},
+						":active": {
+							"color": {
+								"text": "var(--wp--preset--color--secondary)"
+							},
+							"typography": {
+								"textDecoration": "none"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "normal",
+					"lineHeight": "1.4"
+				}
+			}
+		},
+		"color": {
+			"background": "var(--wp--preset--color--base)",
+			"text": "var(--wp--preset--color--contrast)"
+		},
+		"elements": {
+			"button": {
+				"border": {
+					"radius": "0"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--primary)",
+					"text": "var(--wp--preset--color--contrast)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--contrast)",
+						"text": "var(--wp--preset--color--base)"
+					}
+				},
+				":focus": {
+					"color": {
+						"background": "var(--wp--preset--color--contrast)",
+						"text": "var(--wp--preset--color--base)"
+					}
+				},
+				":active": {
+					"color": {
+						"background": "var(--wp--preset--color--secondary)",
+						"text": "var(--wp--preset--color--base)"
+					}
+				},
+				":visited": {
+					"color": {
+						"text": "var(--wp--preset--color--contrast)"
+					}
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "3.625rem",
+					"lineHeight": "1.2"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "clamp(2.625rem, calc(2.625rem + ((1vw - 0.48rem) * 8.4135)), 3.25rem)",
+					"lineHeight": "1.2"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "700",
+					"textTransform": "uppercase"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"textTransform": "uppercase"
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontWeight": "400",
+					"lineHeight": "1.4"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--contrast)"
+				},
+				":hover": {
+					"typography": {
+						"textDecoration": "none"
+					}
+				},
+				":focus": {
+					"typography": {
+						"textDecoration": "underline dashed"
+					}
+				},
+				":active": {
+					"color": {
+						"text": "var(--wp--preset--color--secondary)"
+					},
+					"typography": {
+						"textDecoration": "none"
+					}
+				},
+				"typography": {
+					"textDecoration": "underline"
+				}
+			}
+		},
+		"spacing": {
+			"blockGap": "1.5rem",
+			"padding": {
+				"top": "var(--wp--preset--spacing--40)",
+				"right": "var(--wp--preset--spacing--30)",
+				"bottom": "var(--wp--preset--spacing--40)",
+				"left": "var(--wp--preset--spacing--30)"
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--system-font)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.6"
+		}
+	},
+	"templateParts": [
+		{
+			"area": "header",
+			"name": "header",
+			"title": "Header"
+		},
+		{
+			"area": "footer",
+			"name": "footer",
+			"title": "Footer"
+		},
+		{
+			"area": "uncategorized",
+			"name": "comments",
+			"title": "Comments"
+		},
+		{
+			"area": "uncategorized",
+			"name": "post-meta",
+			"title": "Post Meta"
+		}
+	]
 }

--- a/wp_data/wp-content/themes/mytheme/theme.json
+++ b/wp_data/wp-content/themes/mytheme/theme.json
@@ -1,0 +1,15 @@
+{
+    "version": 2,
+    "settings": {
+        "custom": {
+            "fruit": "apple"
+        },
+        "blocks": {
+            "core/paragraph": {
+                "custom": {
+                    "fruit": "pear"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 変更の概要
WordPress環境構築
来年度のカスタム投稿タイプ追加
ネームと本稿のカスタムタクソノミー追加
## なぜこの変更をするのか
年度ごとの投稿をカスタム投稿タイプで分け、ネームと本稿をカスタムタクソノミーで分けるため
## やったこと
カスタム投稿タイプとカスタムタクソノミーの定義を追加した
## やらないこと
無し
## できるようになること
カスタム投稿タイプを選択できるようになる
## できなくなること
無し
## 動作確認方法
サイトの管理画面を開き、カスタム投稿タイプが表示されることを確認
カスタム投稿タイプから記事を作成できることを確認
## その他
カスタムタクソノミーが選択できないので、それを修正する必要あり