### PR TITLE
タクソノミーの追加、カスタムタクソノミーの削除、全ての投稿一覧が表示できるように変更

### DIFF
--- a/wp_data/wp-content/themes/mytheme/functions.php
+++ b/wp_data/wp-content/themes/mytheme/functions.php
@@ -39,3 +39,11 @@ if (! function_exists('mytheme_setup')) {
     }
 }
 add_action('after_setup_theme', 'mytheme_setup');
+
+function get_all_posts($query)
+{
+    if ($query->is_main_query()) {
+        $query->set('post_type', 'any');
+    }
+}
+add_action('pre_get_posts', 'get_all_posts');

--- a/wp_data/wp-content/themes/mytheme/functions.php
+++ b/wp_data/wp-content/themes/mytheme/functions.php
@@ -21,38 +21,15 @@ function create_post_type()
             'title',  // タイトル
             'editor', // エディター
             'thumbnail', // アイキャッチ画像
+            'excerpt',  // 抜粋
+            'custom-fields', // カスタムフィールド
             'revisions' // リビジョンの保存
           ),
+          'taxonomies' => array('category'), // 使用するタクソノミー
         )
     );
 }
 add_action('init', 'create_post_type');
-
-/* ---------- カスタムタクソノミー（カテゴリー）の追加 ---------- */
-function custom_taxonomy_cat()
-{
-    register_taxonomy( // カスタムタクソノミーの追加関数
-        'naming', // カテゴリーの名前（半角英数字の小文字）
-        'FY2023',     // タグを追加したいカスタム投稿タイプ
-        array(      // オプション（以下
-          'label' => 'ネーム', // 表示名称
-          'public' => true, // 管理画面に表示するかどうかの指定
-          'hierarchical' => true, // 階層を持たせるかどうか
-          'show_in_rest' => true, // REST APIの有効化。ブロックエディタの有効化。
-        )
-    );
-    register_taxonomy( // カスタムタクソノミーの追加関数
-        'completed_manuscript', // カテゴリーの名前（半角英数字の小文字）
-        'FY2023',     // タグを追加したいカスタム投稿タイプ
-        array(      // オプション（以下
-          'label' => '本稿', // 表示名称
-          'public' => true, // 管理画面に表示するかどうかの指定
-          'hierarchical' => true, // 階層を持たせるかどうか
-          'show_in_rest' => true, // REST APIの有効化。ブロックエディタの有効化。
-        )
-    );
-}
-add_action('init', 'custom_taxonomy_cat');
 
 /* ---------- ブロックテーマサポートの追加 ---------- */
 if (! function_exists('mytheme_setup')) {


### PR DESCRIPTION
## 変更の概要
デフォルトのタクソノミーであるカテゴリの追加
カスタムタクソノミーの定義を削除
## なぜこの変更をするのか
タクソノミーの認識を間違っており、カテゴリ内でカテゴリ分けできたため、ネームと本稿のカスタムタクソノミーが不要になった
## やったこと
カテゴリタクソノミーの追加
ネーム、本稿タクソノミーの削除
## やらないこと
無し
## できるようになること
カテゴリタクソノミー内でカテゴリを作成できるようになる
カスタム投稿タイプにカテゴリを追加できるようになる
## できなくなること
無し(ネーム、本稿タクソノミー内でカテゴリ作成ができなくなるが、ネーム、本稿タクソノミーが表示されていなかったため、そもそもできなかった)
## 動作確認方法
カテゴリタクソノミーで新規カテゴリを作成し、投稿のカテゴリ分けを行えることを確認
カテゴリ一覧でそのカテゴリに属している投稿の一覧が見えることを確認
## その他
無し